### PR TITLE
Fix artifact title in listing (use title/artifact/name priority) #241

### DIFF
--- a/src/lib/components/file-list.svelte
+++ b/src/lib/components/file-list.svelte
@@ -1,26 +1,36 @@
 <script lang="ts">
-	import { FolderOpenOutline, FileOutline } from 'flowbite-svelte-icons';
-	import { Listgroup } from 'flowbite-svelte';
+    import { FolderOpenOutline, FileOutline } from 'flowbite-svelte-icons';
+    import { Listgroup } from 'flowbite-svelte';
 
-	export let collection: any[];
-	export let files = true;
-	let iconType = files ? FileOutline : FolderOpenOutline;
+    export let collection: any[];
+    export let files = true;
+    let iconType = files ? FileOutline : FolderOpenOutline;
+
+    // Debug: Print the first artifact to inspect fields (title, artifact, name, etc.)
+    console.log("Artifact sample:", collection?.[0]);
 </script>
 
 <ul>
 	<div class="item-list">
 		<div class="mb-6 grid gap-2 md:grid-cols-1">
 			<div class="item-list-item">
+
+                <!-- MAIN LIST -->
 				<Listgroup items={collection.map((c) => c.name)} let:index>
                     <a href={collection[index]._links?.self?.href ?? '.'}>
                         <li class="flex items-center gap-2" style="min-height: 28px;">
-                            
-                                <svelte:component this={iconType} class="h-4 w-4" />
-                                {collection[index].name}
-                            
+
+                            <svelte:component this={iconType} class="h-4 w-4" />
+
+                            <!-- FIX: Used title → artifact → name (in this priority) -->
+                            {collection[index].title
+                                ?? collection[index].artifact
+                                ?? collection[index].name}
+
                         </li>
                     </a>
 				</Listgroup>
+
 			</div>
 		</div>
 	</div>

--- a/src/lib/components/file-list.svelte
+++ b/src/lib/components/file-list.svelte
@@ -4,10 +4,7 @@
 
     export let collection: any[];
     export let files = true;
-    let iconType = files ? FileOutline : FolderOpenOutline;
-
-    // Debug: Print the first artifact to inspect fields (title, artifact, name, etc.)
-    console.log("Artifact sample:", collection?.[0]);
+    let iconType = files ? FileOutline : FolderOpenOutline;   
 </script>
 
 <ul>


### PR DESCRIPTION
Summary

This PR fixes Issue #241, where the artifact listing displayed an incorrect or confusing title such as:

live-fusion-kg-snapshot - 2025-11-11 - dbpedia-io

Instead of the correct dataset/artifact name, e.g.:

Geo-coordinates

The incorrect title came from using collection[index].name, which often contains a fallback string instead of the proper artifact title.

What was changed

Updated the component:

src/lib/components/file-list.svelte


Replaced:

{collection[index].name}


With:

{collection[index].title ?? collection[index].artifact ?? collection[index].name}


This adds a priority-based fallback mechanism:

1. title (preferred, human-readable)

2. artifact (dataset/artifact name)

3. name (fallback, original behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved file list item labeling to prioritize title, then artifact, then name for clearer identification.
* **Bug Fix**
  * Corrected list item rendering so icons and labels display in the intended order, improving readability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->